### PR TITLE
[thread-spawn] Mark additions with their criticality to the proposal

### DIFF
--- a/proposals/thread-spawn/Overview.md
+++ b/proposals/thread-spawn/Overview.md
@@ -1,11 +1,13 @@
 # [DRAFT] Thread Spawn Proposal
 
 This page describes a proposal to allow WebAssembly modules to spawn threads from within the
-WebAssembly language. This is done with three additions to the specification:
+WebAssembly language. This is done with several additions to the specification (each addition is
+annotated with its criticality to the proposal; next-stage discussions could alter this list):
 
-- a new `thread.spawn` instruction
-- new `shared` attributes on WebAssembly tables, functions, and globals
-- a new `thread.hw_concurrency` instruction
+- __required__: new `shared` attributes on WebAssembly tables, functions, and globals
+- __required in some form__: a new `thread.spawn` instruction (other mechanisms are possible; more
+  discussion needed)
+- __helpful__: a new `thread.hw_concurrency` instruction
 
 Though conceptually simple, this idea has not yet been formally proposed due to several challenges,
 not the least of which is the perceived complexity of implementing all of this safely. Please be

--- a/proposals/thread-spawn/Overview.md
+++ b/proposals/thread-spawn/Overview.md
@@ -7,6 +7,9 @@ annotated with its criticality to the proposal; next-stage discussions could alt
 - __required__: new `shared` attributes on WebAssembly tables, functions, and globals
 - __required in some form__: a new `thread.spawn` instruction (other mechanisms are possible; more
   discussion needed)
+- __required in some form__: a mechanism enabling thread-local storage (e.g., a new `thread.id`
+  instruction)
+- __strongly desired__: a design for JavaScript-WebAssembly interaction
 - __helpful__: a new `thread.hw_concurrency` instruction
 
 Though conceptually simple, this idea has not yet been formally proposed due to several challenges,


### PR DESCRIPTION
After many discussions on the topic, including [this one], there seems to be early consensus on needing to do something along the lines of this proposal but there are differing views on the specific form this might take. I fully expect the proposal to change with more discussion and especially as we prototype and troubleshoot the idea. To capture this in the proposal, I added text indicating how critical each addition is: e.g., if we removed `shared` attributes, this proposal should be closed and replaced by another one. This level of criticality varies for each addition.

[this one]: https://github.com/abrown/thread-spawn/discussions/1